### PR TITLE
Add -allow-origin flag to support using wasmserve in embedded dev environments

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ const indexHTML = `<!DOCTYPE html>
 `
 
 var (
-	flagHTTP = flag.String("http", ":8080", "HTTP bind address to serve")
-	flagTags = flag.String("tags", "", "Build tags")
+	flagHTTP        = flag.String("http", ":8080", "HTTP bind address to serve")
+	flagTags        = flag.String("tags", "", "Build tags")
+	flagAllowOrigin = flag.String("allow-origin", "", "Allow specified origin (or * for all origins) to make requests to this server")
 )
 
 func ensureModule(path string) ([]byte, error) {
@@ -98,6 +99,12 @@ func ensureTmpOutputDir() (string, error) {
 }
 
 func handle(w http.ResponseWriter, r *http.Request) {
+	if *flagAllowOrigin == "*" {
+		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
+	} else if *flagAllowOrigin != "" {
+		w.Header().Set("Access-Control-Allow-Origin", *flagAllowOrigin)
+	}
+
 	output, err := ensureTmpOutputDir()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -99,9 +99,7 @@ func ensureTmpOutputDir() (string, error) {
 }
 
 func handle(w http.ResponseWriter, r *http.Request) {
-	if *flagAllowOrigin == "*" {
-		w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
-	} else if *flagAllowOrigin != "" {
+	if *flagAllowOrigin != "" {
 		w.Header().Set("Access-Control-Allow-Origin", *flagAllowOrigin)
 	}
 


### PR DESCRIPTION
In a larger application (Sourcegraph's documentation site) I am embedding a Go
WebAssembly program within a single page. It is nice that `wasmserve` can handle
automatically recompiling the Go code and serve the `main.wasm` file for me, the
only problem is that when I link to that file wasmserve is serving from the
larger application browsers do not let the requests through due to CORS.

This PR adds an `-allow-origin` flag which lets wasmserve be used when developing
in situations like this. For example, one can just put this in their other
application they wish to develop from:

```
<script src="http://localhost:8080/wasm_exec.js"></script>
<script>
(async () => {
    const urlParams = new URLSearchParams(window.location.search);
    const resp = await fetch('http://localhost:8080/main.wasm');
    if (!resp.ok) {
        const pre = document.createElement('pre');
        pre.innerText = await resp.text();
        document.body.appendChild(pre);
        return;
    }
    const src = await resp.arrayBuffer();
    const go = new Go();
    const result = await WebAssembly.instantiate(src, go.importObject);
    go.run(result.instance);
})();
</script>
```

And then run:

```sh
wasmserve -allow-origin='*'
```

And then the Go code runs in your other application, while being recompiled
automatically by `wasmserve`.