### PR TITLE
Fix subdirectory issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,8 +118,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	upath := r.URL.Path[1:]
-	fpath := filepath.Join(".", filepath.Base(upath))
+	fpath := filepath.Join(".", r.URL.Path)
 	workdir := "."
 
 	if !strings.HasSuffix(r.URL.Path, "/") {

--- a/main.go
+++ b/main.go
@@ -118,7 +118,8 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fpath := filepath.Join(".", r.URL.Path)
+	upath := r.URL.Path[1:]
+	fpath := filepath.Join(".", filepath.Base(upath))
 	workdir := "."
 
 	if !strings.HasSuffix(r.URL.Path, "/") {
@@ -133,12 +134,8 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if strings.HasSuffix(r.URL.Path, "/") {
-		fpath = filepath.Join(fpath, "index.html")
-	}
-
 	switch filepath.Base(fpath) {
-	case "index.html":
+	case "index.html", ".":
 		if _, err := os.Stat(fpath); err != nil && !os.IsNotExist(err) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -198,7 +195,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.ServeFile(w, r, fpath)
+	http.ServeFile(w, r, filepath.Join(".", r.URL.Path))
 }
 
 func main() {


### PR DESCRIPTION
#10 
The original code used the base of the requested path and therefore removing the directory that the requested file was in.
I have rectified this issue and tested it with my own project (which did not previously work with wasmserve due to this very issue) and now it works 100%.