### PR TITLE
feat: add new flag `workdir` to specify the serve path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Usage of wasmserve
         HTTP bind address to serve (default ":8080")
   -tags string
         Build tags
+  -workdir specify the build workdir path
 ```
 
 ## Example

--- a/main.go
+++ b/main.go
@@ -143,7 +143,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		log.Print("go ", strings.Join(args, " "))
 		cmdBuild := exec.Command("go", args...)
 		cmdBuild.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
-		// If GO111MODULE is not specified explicilty, enable Go modules.
+		// If GO111MODULE is not specified explicitly, enable Go modules.
 		// Enabling this is for backward compatibility of wasmserve.
 		if !hasGo111Module(cmdBuild.Env) {
 			cmdBuild.Env = append(cmdBuild.Env, "GO111MODULE=on")

--- a/main.go
+++ b/main.go
@@ -56,38 +56,9 @@ var (
 	flagWorkdirPath = flag.String("workdir", ".", "specify the build workdir path")
 )
 
-func ensureModule(path string) ([]byte, error) {
-	_, err := os.Stat(filepath.Join(path, "go.mod"))
-	if err == nil {
-		return nil, nil
-	}
-	if !os.IsNotExist(err) {
-		return nil, err
-	}
-	log.Print("(", path, ")")
-	log.Print("go mod init example.com/m")
-	cmd := exec.Command("go", "mod", "init", "example.com/m")
-	cmd.Dir = path
-	return cmd.CombinedOutput()
-}
-
 var (
-	tmpWorkDir   = ""
 	tmpOutputDir = ""
 )
-
-func ensureTmpWorkDir() (string, error) {
-	if tmpWorkDir != "" {
-		return tmpWorkDir, nil
-	}
-
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		return "", err
-	}
-	tmpWorkDir = tmp
-	return tmpWorkDir, nil
-}
 
 func ensureTmpOutputDir() (string, error) {
 	if tmpOutputDir != "" {


### PR DESCRIPTION
Without the `workdir` , I can only `cd` to the static directory and run `wasmserve` to serve my static files , but it is really inconvenient , can we add the workdir flag to help us with this ?

And PR includes some dead code deleted and typo fixed .