### PR TITLE
Support auto-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Usage of wasmserve
 
 # Trigger Refresh
 
-Once the browser loads the page, you can trigger a reload by making a call to teh server at `/__notify`, like this:
+Once the browser loads the page, you can trigger a reload by making a call to teh server at `/_notify`, like this:
 
 ```sh
-curl localhost:8080/__notify
+curl localhost:8080/_notify
 ```
 
 This will make the browser reload. You can add this command to a build script or to an IDE command, to have the browser automatically update without leaving your IDE.
@@ -67,7 +67,7 @@ This application sometimes does not work under WSL, due to bugs in WSL, see http
 
 * To trigger a browser reload from a script, make a call to `/_notify`, like this:
 
-```
+```sh
 curl http://localhost:8080/_notify
 ```
 This will make the browser refresh the page.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Usage of wasmserve
         Build tags
 ```
 
+# Trigger Refresh
+
+Once the browser loads the page, you can trigger a reload by making a call to teh server at `/__notify`, like this:
+
+```sh
+curl localhost:8080/__notify
+```
+
+This will make the browser reload. You can add this command to a build script or to an IDE command, to have the browser automatically update without leaving your IDE.
+
 ## Example
 
 Running a remote package
@@ -49,8 +59,15 @@ This application sometimes does not work under WSL, due to bugs in WSL, see http
 
 ## Tips
 
-If you want to change the working directory to serve, you can use cd with parentheses:
+* If you want to change the working directory to serve, you can use cd with parentheses:
 
 ```
 (cd /path/to/working/dir; wasmserve github.com/yourname/yourpackage)
 ```
+
+* To trigger a browser reload from a script, make a call to `/_notify`, like this:
+
+```
+curl http://localhost:8080/_notify
+```
+This will make the browser refresh the page.

--- a/main.go
+++ b/main.go
@@ -40,13 +40,17 @@ const indexHTML = `<!DOCTYPE html>
     const pre = document.createElement('pre');
     pre.innerText = await resp.text();
     document.body.appendChild(pre);
-    return;
+  } else {
+    const src = await resp.arrayBuffer();
+    const go = new Go();
+    const result = await WebAssembly.instantiate(src, go.importObject);
+    go.argv = {{.Argv}};
+    go.run(result.instance);
   }
-  const src = await resp.arrayBuffer();
-  const go = new Go();
-  const result = await WebAssembly.instantiate(src, go.importObject);
-  go.argv = {{.Argv}};
-  go.run(result.instance);
+  const reload = await fetch('__wait');
+  if (reload.ok) {
+    location.reload();
+  }
 })();
 </script>
 `
@@ -59,6 +63,7 @@ var (
 
 var (
 	tmpOutputDir = ""
+	waitChannel  = make(chan struct{})
 )
 
 func ensureTmpOutputDir() (string, error) {
@@ -175,9 +180,36 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		defer f.Close()
 		http.ServeContent(w, r, "main.wasm", time.Now(), f)
 		return
+
+	case "__wait":
+		waitForUpdate(w, r)
+		return
+	case "__notify":
+		notifyWaiters(w, r)
+		return
 	}
 
 	http.ServeFile(w, r, filepath.Join(".", r.URL.Path))
+}
+
+func waitForUpdate(w http.ResponseWriter, r *http.Request) {
+	// Channels are many-writers-single-reader device.
+	// so wait-ers are the writers for us...
+
+	waitChannel <- struct{}{}
+	http.ServeContent(w, r, "", time.Now(), bytes.NewReader(nil))
+}
+
+func notifyWaiters(w http.ResponseWriter, r *http.Request) {
+	for {
+		select {
+		case <-waitChannel:
+			// dump message
+		default:
+			http.ServeContent(w, r, "", time.Now(), bytes.NewReader(nil))
+			return
+		}
+	}
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -202,7 +202,6 @@ func notifyWaiters(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-waitChannel:
-
 		default:
 			http.ServeContent(w, r, "", time.Now(), bytes.NewReader(nil))
 			return

--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ const indexHTML = `<!DOCTYPE html>
     go.argv = {{.Argv}};
     go.run(result.instance);
   }
-  const reload = await fetch('__wait');
+  const reload = await fetch('_wait');
+  // The server sends a response for '_wait' when a request is sent to '_notify'.
   if (reload.ok) {
     location.reload();
   }
@@ -181,10 +182,10 @@ func handle(w http.ResponseWriter, r *http.Request) {
 		http.ServeContent(w, r, "main.wasm", time.Now(), f)
 		return
 
-	case "__wait":
+	case "_wait":
 		waitForUpdate(w, r)
 		return
-	case "__notify":
+	case "_notify":
 		notifyWaiters(w, r)
 		return
 	}
@@ -193,9 +194,6 @@ func handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func waitForUpdate(w http.ResponseWriter, r *http.Request) {
-	// Channels are many-writers-single-reader device.
-	// so wait-ers are the writers for us...
-
 	waitChannel <- struct{}{}
 	http.ServeContent(w, r, "", time.Now(), bytes.NewReader(nil))
 }
@@ -204,7 +202,7 @@ func notifyWaiters(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case <-waitChannel:
-			// dump message
+
 		default:
 			http.ServeContent(w, r, "", time.Now(), bytes.NewReader(nil))
 			return


### PR DESCRIPTION
Allowe server to trigger a reload in the browser.
To trigger, run something like `curl localhost:8080/__notify` whenever you feel like it (or from a build script).

This doesn't watch the filesystem, becasue I expect that in most cases the first change in code will break it.

Close #15.