### PR TITLE
Update README.md - Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An HTTP server for Wasm testing like `gopherjs serve`
 ## Installation
 
 ```sh
-go get -u github.com/hajimehoshi/wasmserve
+go install github.com/hajimehoshi/wasmserve@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go get -u` is deprecated, should use `go install` (I think :) ).

Tested working on my machine, of course.