### PR TITLE
serve a file if exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/hajimehoshi/wasmserve
 
-go 1.12
+go 1.16

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	upath := r.URL.Path[1:]
-	fpath := filepath.FromSlash(path.Base(upath))
+	fpath := path.Base(upath)
 	workdir := "."
 
 	if !strings.HasSuffix(r.URL.Path, "/") {


### PR DESCRIPTION
Originally wasmserve served files like index.html if exists, but
accidentally this feature was removed at https://github.com/hajimehoshi/wasmserve/commit/0e21cc99ec1d8904a6fbdf17ff204cf1cf921196.

This change revives this feature.