### PR TITLE
ensure at least 1 element in fargs

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func handle(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if errors.Is(err, fs.ErrNotExist) {
 			fargs := flag.Args()
+			if len(fargs) == 0 {
+				fargs = []string{filepath.Join(output, "main.wasm")}
+			}
 			argv := make([]string, 0, len(fargs))
 			for _, a := range fargs {
 				argv = append(argv, `"`+template.JSEscapeString(a)+`"`)


### PR DESCRIPTION
packages such as `flag` will attempt to access `os.Args[0]`, so we should ensure that at least 1 arg is passed to the WASM side.
