### PR TITLE
Graceful shutdown on sigint

### DIFF
--- a/main.go
+++ b/main.go
@@ -389,7 +389,7 @@ func main() {
 		close(shutdown)
 
 		<-sigint
-		// hard exit the second ctrl-c
+		// Hard exit the second ctrl-c
 		os.Exit(0)
 	}()
 

--- a/main.go
+++ b/main.go
@@ -389,7 +389,7 @@ func main() {
 		close(shutdown)
 
 		<-sigint
-		// Hard exit the second ctrl-c
+		// Hard exit on the second ctrl-c
 		os.Exit(0)
 	}()
 

--- a/main.go
+++ b/main.go
@@ -245,8 +245,6 @@ func goBuild(outputPath string) error {
 		return err
 	}
 
-	log.Printf("Building wasm output")
-
 	// buildDir is the directory to build the Wasm binary.
 	buildDir := "."
 

--- a/main.go
+++ b/main.go
@@ -373,7 +373,7 @@ func main() {
 
 	var server http.Server
 
-	idleConnsClosed := make(chan struct{})
+	shutdown := make(chan struct{})
 	go func() {
 		sigint := make(chan os.Signal, 1)
 		signal.Notify(sigint, os.Interrupt)
@@ -389,7 +389,7 @@ func main() {
 			// Error from closing listeners, or context timeout:
 			log.Printf("HTTP server Shutdown: %v", err)
 		}
-		close(idleConnsClosed)
+		close(shutdown)
 
 		<-sigint
 		// hard exit the second ctrl-c
@@ -407,7 +407,7 @@ func main() {
 		log.Printf("Error running webserver: %v", err)
 	}
 
-	<-idleConnsClosed
+	<-shutdown
 
 	log.Printf("Exiting")
 }

--- a/main.go
+++ b/main.go
@@ -389,7 +389,7 @@ func main() {
 		close(shutdown)
 
 		<-sigint
-		// Hard exit on the second ctrl-c
+		// Hard exit on the second ctrl-c.
 		os.Exit(0)
 	}()
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+    "context"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -26,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+    "os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -243,6 +245,8 @@ func goBuild(outputPath string) error {
 		return err
 	}
 
+    log.Printf("Building wasm output")
+
 	// buildDir is the directory to build the Wasm binary.
 	buildDir := "."
 
@@ -357,7 +361,52 @@ func notifyWaiters(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+    log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds)
 	flag.Parse()
-	http.HandleFunc("/", handle)
-	log.Fatal(http.ListenAndServe(*flagHTTP, nil))
+
+    tmpDir, err := ensureTmpOutputDir()
+    if err != nil {
+        log.Fatalf("Failed to create temporary directory: %v", err)
+    }
+
+    defer os.RemoveAll(tmpDir)
+
+    var server http.Server
+
+    idleConnsClosed := make(chan struct{})
+    go func() {
+        sigint := make(chan os.Signal, 1)
+        signal.Notify(sigint, os.Interrupt)
+        <-sigint
+
+        log.Printf("Shutting down server...")
+
+        // We received an interrupt signal, shut down.
+        ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Millisecond)
+        defer cancel()
+        err := server.Shutdown(ctx)
+        if err != nil && !errors.Is(err, context.DeadlineExceeded){
+            // Error from closing listeners, or context timeout:
+            log.Printf("HTTP server Shutdown: %v", err)
+        }
+        close(idleConnsClosed)
+
+        <-sigint
+        // hard exit the second ctrl-c
+        os.Exit(0)
+    }()
+
+    serveMux := http.NewServeMux()
+    server.Handler = serveMux
+	serveMux.HandleFunc("/", handle)
+    log.Printf("Listening on %v", *flagHTTP)
+    server.Addr = *flagHTTP
+    err = server.ListenAndServe()
+    if err != nil && !errors.Is(err, http.ErrServerClosed) {
+        log.Printf("Error running webserver: %v", err)
+    }
+
+    <-idleConnsClosed
+
+    log.Printf("Exiting")
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"bytes"
-    "context"
+	"context"
 	"encoding/base64"
 	"errors"
 	"flag"
@@ -27,7 +27,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-    "os/signal"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -245,7 +245,7 @@ func goBuild(outputPath string) error {
 		return err
 	}
 
-    log.Printf("Building wasm output")
+	log.Printf("Building wasm output")
 
 	// buildDir is the directory to build the Wasm binary.
 	buildDir := "."
@@ -361,52 +361,52 @@ func notifyWaiters(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-    log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds)
+	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds)
 	flag.Parse()
 
-    tmpDir, err := ensureTmpOutputDir()
-    if err != nil {
-        log.Fatalf("Failed to create temporary directory: %v", err)
-    }
+	tmpDir, err := ensureTmpOutputDir()
+	if err != nil {
+		log.Fatalf("Failed to create temporary directory: %v", err)
+	}
 
-    defer os.RemoveAll(tmpDir)
+	defer os.RemoveAll(tmpDir)
 
-    var server http.Server
+	var server http.Server
 
-    idleConnsClosed := make(chan struct{})
-    go func() {
-        sigint := make(chan os.Signal, 1)
-        signal.Notify(sigint, os.Interrupt)
-        <-sigint
+	idleConnsClosed := make(chan struct{})
+	go func() {
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, os.Interrupt)
+		<-sigint
 
-        log.Printf("Shutting down server...")
+		log.Printf("Shutting down server...")
 
-        // We received an interrupt signal, shut down.
-        ctx, cancel := context.WithTimeout(context.Background(), 10 * time.Millisecond)
-        defer cancel()
-        err := server.Shutdown(ctx)
-        if err != nil && !errors.Is(err, context.DeadlineExceeded){
-            // Error from closing listeners, or context timeout:
-            log.Printf("HTTP server Shutdown: %v", err)
-        }
-        close(idleConnsClosed)
+		// We received an interrupt signal, shut down.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+		err := server.Shutdown(ctx)
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			// Error from closing listeners, or context timeout:
+			log.Printf("HTTP server Shutdown: %v", err)
+		}
+		close(idleConnsClosed)
 
-        <-sigint
-        // hard exit the second ctrl-c
-        os.Exit(0)
-    }()
+		<-sigint
+		// hard exit the second ctrl-c
+		os.Exit(0)
+	}()
 
-    serveMux := http.NewServeMux()
-    server.Handler = serveMux
+	serveMux := http.NewServeMux()
+	server.Handler = serveMux
 	serveMux.HandleFunc("/", handle)
-    log.Printf("Listening on %v", *flagHTTP)
-    server.Addr = *flagHTTP
-    err = server.ListenAndServe()
-    if err != nil && !errors.Is(err, http.ErrServerClosed) {
-        log.Printf("Error running webserver: %v", err)
-    }
+	log.Printf("Listening on %v", *flagHTTP)
+	server.Addr = *flagHTTP
+	err = server.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Printf("Error running webserver: %v", err)
+	}
 
-    <-idleConnsClosed
+	<-idleConnsClosed
 
-    log.Printf("Exiting")
+	log.Printf("Exiting")
 }

--- a/main.go
+++ b/main.go
@@ -387,7 +387,7 @@ func main() {
 		err := server.Shutdown(ctx)
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			// Error from closing listeners, or context timeout:
-			log.Printf("HTTP server Shutdown: %v", err)
+			log.Printf("Error at server.Shutdown: %v", err)
 		}
 		close(shutdown)
 

--- a/main.go
+++ b/main.go
@@ -361,7 +361,6 @@ func notifyWaiters(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	log.SetFlags(log.Lshortfile | log.Ldate | log.Lmicroseconds)
 	flag.Parse()
 
 	tmpDir, err := ensureTmpOutputDir()

--- a/main.go
+++ b/main.go
@@ -404,7 +404,7 @@ func main() {
 	log.Printf("Listening on %v", *flagHTTP)
 	err = server.ListenAndServe()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
-		log.Printf("Error running webserver: %v", err)
+		log.Printf("Error at server.ListenAndServe: %v", err)
 	}
 
 	<-shutdown

--- a/main.go
+++ b/main.go
@@ -381,7 +381,7 @@ func main() {
 
 		log.Printf("Shutting down server...")
 
-		// We received an interrupt signal, shut down.
+		// Received an interrupt signal, shut down.
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 		defer cancel()
 		err := server.Shutdown(ctx)

--- a/main.go
+++ b/main.go
@@ -383,7 +383,6 @@ func main() {
 		defer cancel()
 		err := server.Shutdown(ctx)
 		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-			// Error from closing listeners, or context timeout:
 			log.Printf("Error at server.Shutdown: %v", err)
 		}
 		close(shutdown)

--- a/main.go
+++ b/main.go
@@ -396,11 +396,12 @@ func main() {
 		os.Exit(0)
 	}()
 
-	serveMux := http.NewServeMux()
-	server.Handler = serveMux
-	serveMux.HandleFunc("/", handle)
-	log.Printf("Listening on %v", *flagHTTP)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handle)
+	server.Handler = mux
 	server.Addr = *flagHTTP
+
+	log.Printf("Listening on %v", *flagHTTP)
 	err = server.ListenAndServe()
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Printf("Error running webserver: %v", err)


### PR DESCRIPTION
The wasmserver program creates a temporary directory to store the built main.wasm binary but does not clean up the temporary directory on shutdown. This PR catches ctrl-c and performs a clean shutdown. The changes are roughly

1. call os.RemoveAll(tmpdir) in main()
2. use a non-default http.Server so that it can be shutdown via server.Shutdown()
3. use os.Signal to catch sigint

Also I added some extra minor logging so the behavior of the server was more apparent.

Output on my system:
```
2024/05/05 19:32:51.666789 main.go:402: Listening on :8080
2024/05/05 19:32:52.978744 main.go:248: Building wasm output
2024/05/05 19:32:52.978775 main.go:301: go build -o /tmp/609277792/main.wasm ./cmd/shooter
^C2024/05/05 19:32:56.928758 main.go:382: Shutting down server...
2024/05/05 19:32:56.939859 main.go:411: Exiting
```